### PR TITLE
Update links to PyTorch Lightning documentation

### DIFF
--- a/lab1/readme.md
+++ b/lab1/readme.md
@@ -80,7 +80,7 @@ In the process of doing the above, `DataModule`s make use of a couple of other c
 
 If need be, you can read more about these [PyTorch data interfaces](https://pytorch.org/docs/stable/data.html).
 
-To avoid writing same old boilerplate for all of our data sources, we define a simple base class `text_recognizer.data.BaseDataModule` which in turn inherits from [`pl.LightningDataModule`](https://pytorch-lightning.readthedocs.io/en/latest/datamodules.html).
+To avoid writing same old boilerplate for all of our data sources, we define a simple base class `text_recognizer.data.BaseDataModule` which in turn inherits from [`pl.LightningDataModule`](https://pytorch-lightning.readthedocs.io/en/latest/extensions/datamodules.html).
 This inheritance will let us use the data very simply with PyTorch-Lightning `Trainer` and avoid common problems with distributed training.
 
 ### Models

--- a/lab1/text_recognizer/data/base_data_module.py
+++ b/lab1/text_recognizer/data/base_data_module.py
@@ -43,7 +43,7 @@ NUM_WORKERS = 0
 class BaseDataModule(pl.LightningDataModule):
     """
     Base DataModule.
-    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/datamodules.html
+    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/extensions/datamodules.html
     """
 
     def __init__(self, args: argparse.Namespace = None) -> None:

--- a/lab1/text_recognizer/data/mnist.py
+++ b/lab1/text_recognizer/data/mnist.py
@@ -19,7 +19,7 @@ urllib.request.install_opener(opener)
 class MNIST(BaseDataModule):
     """
     MNIST DataModule.
-    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/datamodules.html
+    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/extensions/datamodules.html
     """
 
     def __init__(self, args: argparse.Namespace) -> None:

--- a/lab2/text_recognizer/data/base_data_module.py
+++ b/lab2/text_recognizer/data/base_data_module.py
@@ -43,7 +43,7 @@ NUM_WORKERS = 0
 class BaseDataModule(pl.LightningDataModule):
     """
     Base DataModule.
-    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/datamodules.html
+    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/extensions/datamodules.html
     """
 
     def __init__(self, args: argparse.Namespace = None) -> None:

--- a/lab2/text_recognizer/data/mnist.py
+++ b/lab2/text_recognizer/data/mnist.py
@@ -19,7 +19,7 @@ urllib.request.install_opener(opener)
 class MNIST(BaseDataModule):
     """
     MNIST DataModule.
-    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/datamodules.html
+    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/extensions/datamodules.html
     """
 
     def __init__(self, args: argparse.Namespace) -> None:

--- a/lab3/text_recognizer/data/base_data_module.py
+++ b/lab3/text_recognizer/data/base_data_module.py
@@ -43,7 +43,7 @@ NUM_WORKERS = 0
 class BaseDataModule(pl.LightningDataModule):
     """
     Base DataModule.
-    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/datamodules.html
+    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/extensions/datamodules.html
     """
 
     def __init__(self, args: argparse.Namespace = None) -> None:

--- a/lab3/text_recognizer/data/mnist.py
+++ b/lab3/text_recognizer/data/mnist.py
@@ -19,7 +19,7 @@ urllib.request.install_opener(opener)
 class MNIST(BaseDataModule):
     """
     MNIST DataModule.
-    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/datamodules.html
+    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/extensions/datamodules.html
     """
 
     def __init__(self, args: argparse.Namespace) -> None:

--- a/lab4/text_recognizer/data/base_data_module.py
+++ b/lab4/text_recognizer/data/base_data_module.py
@@ -43,7 +43,7 @@ NUM_WORKERS = 0
 class BaseDataModule(pl.LightningDataModule):
     """
     Base DataModule.
-    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/datamodules.html
+    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/extensions/datamodules.html
     """
 
     def __init__(self, args: argparse.Namespace = None) -> None:

--- a/lab4/text_recognizer/data/mnist.py
+++ b/lab4/text_recognizer/data/mnist.py
@@ -19,7 +19,7 @@ urllib.request.install_opener(opener)
 class MNIST(BaseDataModule):
     """
     MNIST DataModule.
-    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/datamodules.html
+    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/extensions/datamodules.html
     """
 
     def __init__(self, args: argparse.Namespace) -> None:

--- a/lab5/text_recognizer/data/base_data_module.py
+++ b/lab5/text_recognizer/data/base_data_module.py
@@ -43,7 +43,7 @@ NUM_WORKERS = 0
 class BaseDataModule(pl.LightningDataModule):
     """
     Base DataModule.
-    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/datamodules.html
+    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/extensions/datamodules.html
     """
 
     def __init__(self, args: argparse.Namespace = None) -> None:

--- a/lab5/text_recognizer/data/mnist.py
+++ b/lab5/text_recognizer/data/mnist.py
@@ -19,7 +19,7 @@ urllib.request.install_opener(opener)
 class MNIST(BaseDataModule):
     """
     MNIST DataModule.
-    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/datamodules.html
+    Learn more at https://pytorch-lightning.readthedocs.io/en/stable/extensions/datamodules.html
     """
 
     def __init__(self, args: argparse.Namespace) -> None:


### PR DESCRIPTION
This PR fixes some broken links to PyTorch Lightning's `DataModule` documentation.