### PR TITLE
Update run_experiment.py

### DIFF
--- a/lab1/training/run_experiment.py
+++ b/lab1/training/run_experiment.py
@@ -7,7 +7,7 @@ import torch
 import pytorch_lightning as pl
 import wandb
 
-from text_recognizer import lit_models
+from text_recognizer.lit_models import base
 
 
 # In order to ensure reproducible experiments, we must set random seeds.
@@ -29,12 +29,14 @@ def _setup_parser():
 
     # Add Trainer specific arguments, such as --max_epochs, --gpus, --precision
     trainer_parser = pl.Trainer.add_argparse_args(parser)
-    trainer_parser._action_groups[1].title = "Trainer Args"  # pylint: disable=protected-access
+    trainer_parser._action_groups[
+        1
+    ].title = "Trainer Args"  # pylint: disable=protected-access
     parser = argparse.ArgumentParser(add_help=False, parents=[trainer_parser])
 
     # Basic arguments
-    parser.add_argument("--data_class", type=str, default="MNIST")
-    parser.add_argument("--model_class", type=str, default="MLP")
+    parser.add_argument("--data_class", type=str, default="mnist.MNIST")
+    parser.add_argument("--model_class", type=str, default="mlp.MLP")
     parser.add_argument("--load_checkpoint", type=str, default=None)
 
     # Get the data and model classes, so that we can add their specific arguments
@@ -50,7 +52,7 @@ def _setup_parser():
     model_class.add_to_argparse(model_group)
 
     lit_model_group = parser.add_argument_group("LitModel Args")
-    lit_models.BaseLitModel.add_to_argparse(lit_model_group)
+    base.BaseLitModel.add_to_argparse(lit_model_group)
 
     parser.add_argument("--help", "-h", action="help")
     return parser
@@ -62,7 +64,7 @@ def main():
 
     Sample command:
     ```
-    python training/run_experiment.py --max_epochs=3 --gpus='0,' --num_workers=20 --model_class=MLP --data_class=MNIST
+    python training/run_experiment.py --max_epochs=3 --gpus='0,' --num_workers=20 --model_class=mlp.MLP --data_class=mnist.MNIST
     ```
     """
     parser = _setup_parser()
@@ -73,31 +75,40 @@ def main():
     model = model_class(data_config=data.config(), args=args)
 
     if args.loss not in ("ctc", "transformer"):
-        lit_model_class = lit_models.BaseLitModel
+        lit_model_class = base.BaseLitModel
 
     if args.load_checkpoint is not None:
-        lit_model = lit_model_class.load_from_checkpoint(args.load_checkpoint, args=args, model=model)
+        lit_model = lit_model_class.load_from_checkpoint(
+            args.load_checkpoint, args=args, model=model
+        )
     else:
         lit_model = lit_model_class(args=args, model=model)
 
     logger = pl.loggers.TensorBoardLogger("training/logs")
 
-    early_stopping_callback = pl.callbacks.EarlyStopping(monitor="val_loss", mode="min", patience=10)
+    early_stopping_callback = pl.callbacks.EarlyStopping(
+        monitor="val_loss", mode="min", patience=10
+    )
     model_checkpoint_callback = pl.callbacks.ModelCheckpoint(
-        filename="{epoch:03d}-{val_loss:.3f}-{val_cer:.3f}", monitor="val_loss", mode="min"
+        filename="{epoch:03d}-{val_loss:.3f}-{val_cer:.3f}",
+        monitor="val_loss",
+        mode="min",
     )
     callbacks = [early_stopping_callback, model_checkpoint_callback]
 
     args.weights_summary = "full"  # Print full summary of the model
-    trainer = pl.Trainer.from_argparse_args(args, callbacks=callbacks, logger=logger, weights_save_path="training/logs")
+    trainer = pl.Trainer.from_argparse_args(
+        args, callbacks=callbacks, logger=logger, weights_save_path="training/logs"
+    )
 
     # pylint: disable=no-member
-    trainer.tune(lit_model, datamodule=data)  # If passing --auto_lr_find, this will set learning rate
+    trainer.tune(
+        lit_model, datamodule=data
+    )  # If passing --auto_lr_find, this will set learning rate
 
     trainer.fit(lit_model, datamodule=data)
     trainer.test(lit_model, datamodule=data)
     # pylint: enable=no-member
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Import error
- AttributeError `from text_recognizer import lit_models`. Complications to argparse importing BaseLitModel , change the import reference to `from text_recognizer.lit_models import base` and refactor variable
- AttributeError ```
parser.add_argument("--data_class", type=str, default="MNIST")
parser.add_argument("--model_class", type=str, default="MLP")
``` no class MNIST or MLP attribute in parse. Propose change to refer args to mnist.MNIST and mlp.MLP