### PR TITLE
fix error: get accuracy in ctc loss

### DIFF
--- a/lab3/text_recognizer/lit_models/ctc.py
+++ b/lab3/text_recognizer/lit_models/ctc.py
@@ -1,6 +1,7 @@
 import argparse
 import itertools
 import torch
+import pytorch_lightning as pl
 
 from .base import BaseLitModel
 from .metrics import CharacterErrorRate
@@ -45,6 +46,10 @@ class CTCLitModel(BaseLitModel):  # pylint: disable=too-many-ancestors
 
         self.loss_fn = torch.nn.CTCLoss(zero_infinity=True)
         # https://pytorch.org/docs/stable/generated/torch.nn.CTCLoss.html
+        
+        self.train_acc = pl.metrics.Accuracy()
+        self.val_acc = pl.metrics.Accuracy()
+        self.test_acc = pl.metrics.Accuracy()
 
         ignore_tokens = [start_index, end_index, self.padding_index]
         self.val_cer = CharacterErrorRate(ignore_tokens)


### PR DESCRIPTION
In this lab3, we will experiment with loss through Cross-Entropy and CTC. 
In the case of CE, there is no error in executing the implemented code 
but in the case of CTC, an error occurs in obtaining acc as it inherits BaseLitModel because greedy_decoder
Therefore, in order to see acc correctly in CTC, need to override the inherited function.